### PR TITLE
Update searchForm so if the user picks a date both date inputs will b…

### DIFF
--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -18,6 +18,25 @@ export default function SearchForm() {
   const [guestNumber, setGuestNumber] = useState(2);
   const [roomNumber, setRoomNumber] = useState(1);
 
+  const handleCheckinChange = (date) => {
+    setCheckinDate(date);
+
+    if (!checkoutDate) {
+      setCheckoutDate(date.add(1, "day"));
+    } else if (checkoutDate && date.isAfter(checkoutDate)) {
+      setCheckoutDate(date.add(1, "day"));
+    }
+  };
+
+  const handleCheckoutChange = (date) => {
+    setCheckoutDate(date);
+    if (!checkinDate) {
+      setCheckinDate(date.subtract(1, "day"));
+    } else if (checkinDate && date.isBefore(checkinDate)) {
+      setCheckinDate(date.subtract(1, "day"));
+    }
+  };
+
   const handleSubmit = (event) => {
     event.preventDefault();
 
@@ -71,27 +90,25 @@ export default function SearchForm() {
                 />
               </Grid>
 
-              <Grid item xs={14} md={2.5}>
-                <LocalizationProvider dateAdapter={AdapterDayjs}>
+              <LocalizationProvider dateAdapter={AdapterDayjs}>
+                <Grid item xs={14} md={2.5}>
                   <DatePicker
                     label="Check-in date"
                     sx={{ width: "100%" }}
                     value={checkinDate}
-                    onChange={(newValue) => setCheckinDate(newValue)}
+                    onChange={handleCheckinChange}
                   />
-                </LocalizationProvider>
-              </Grid>
+                </Grid>
 
-              <Grid item xs={14} md={2.5}>
-                <LocalizationProvider dateAdapter={AdapterDayjs}>
+                <Grid item xs={14} md={2.5}>
                   <DatePicker
                     sx={{ width: "100%" }}
                     label="Check-out date"
                     value={checkoutDate}
-                    onChange={(newValue) => setCheckoutDate(newValue)}
+                    onChange={handleCheckoutChange}
                   />
-                </LocalizationProvider>
-              </Grid>
+                </Grid>
+              </LocalizationProvider>
 
               <Grid item xs={14} md={1.5}>
                 <TextField


### PR DESCRIPTION
## Description

Update searchForm so if the user picks a date both date inputs will be auto fill. User can sill change the auto fill dates. 

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? -->

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->


### After

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria
Fill out checkin and checkout date inputs: 
If checkin date is pick, checkout date should be the next day. If checkout date is pick, checkin date should be the prev day. If checkout date is before checkin date then checkout stays the same and checkin date is the day before.
<!-- Provide steps the other team members and mentors need to follow to properly test your additions. -->
