### PR TITLE
Add alert message if authentication went wrong

### DIFF
--- a/src/pages/SignIn.js
+++ b/src/pages/SignIn.js
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React, { useState } from "react";
 import { Link as ReactRouterLink } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
@@ -17,11 +17,15 @@ import {
   Checkbox,
   FormControlLabel,
   Link,
+  Alert,
 } from "@mui/material";
 
 const theme = createTheme();
 
 export default function SignIn() {
+  const [isError, setIsError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
   const navigate = useNavigate();
 
   const handleSubmit = async (event) => {
@@ -34,10 +38,10 @@ export default function SignIn() {
 
     fetchSignin(submissionData).then((returnMessage) => {
       if (returnMessage.user) {
-        console.log(returnMessage);
         return navigate("/");
       } else {
-        console.log(returnMessage.error);
+        setErrorMessage(returnMessage.msg);
+        setIsError(true);
       }
     });
   };
@@ -93,6 +97,11 @@ export default function SignIn() {
             >
               Sign In
             </Button>
+            {isError ? (
+              <Alert sx={{ marginBottom: "8px" }} severity="error">
+                {errorMessage}
+              </Alert>
+            ) : null}
             <Grid container>
               <Grid item xs>
                 <Link component={ReactRouterLink} to="/forgotpassword">

--- a/src/pages/SignUp.js
+++ b/src/pages/SignUp.js
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React, { useState } from "react";
 import { Link as ReactRouterLink } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
@@ -14,12 +14,16 @@ import {
   ThemeProvider,
   createTheme,
   Link,
+  Alert,
 } from "@mui/material";
 import fetchSignup from "../api/fetchSignup";
 
 const theme = createTheme();
 
 export default function SignUp() {
+  const [isError, setIsError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(false);
+
   const navigate = useNavigate();
 
   const handleSubmit = async (event) => {
@@ -36,7 +40,8 @@ export default function SignUp() {
       if (returnMessage.user) {
         return navigate("/");
       } else {
-        console.log(returnMessage.error);
+        setErrorMessage(returnMessage.msg);
+        setIsError(true);
       }
     });
   };
@@ -112,6 +117,11 @@ export default function SignUp() {
             >
               Sign Up
             </Button>
+            {isError ? (
+              <Alert sx={{ marginBottom: "8px" }} severity="error">
+                {errorMessage}
+              </Alert>
+            ) : null}
             <Grid container justifyContent="flex-end">
               <Grid item>
                 <Link component={ReactRouterLink} to="/signin">


### PR DESCRIPTION
## Description

Add Alert if authentication went wrong or some other error for both sigin and signup pages.
<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? -->

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->


### After

![image](https://user-images.githubusercontent.com/74852114/234977451-b18b7af8-c69f-4588-aa28-0d20c2b03fbf.png)

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria

Requires updated backend
Add existing email to signup page and returns a error message of Email already exists. 
In signin give incorrect email or password and returns a error message of Invalid Credentials
<!-- Provide steps the other team members and mentors need to follow to properly test your additions. -->
